### PR TITLE
fix: zero default row index throw an error

### DIFF
--- a/transaction.ts
+++ b/transaction.ts
@@ -304,7 +304,7 @@ class ClientTransaction {
   private getAnimationKey(keyBytes: number[], response?: Document): string {
     const totalTime = 4096;
 
-    if (!this.DEFAULT_ROW_INDEX || !this.DEFAULT_KEY_BYTES_INDICES) {
+    if (typeof this.DEFAULT_ROW_INDEX !== 'number' || !this.DEFAULT_KEY_BYTES_INDICES) {
       throw new Error("Indices not initialized");
     }
 


### PR DESCRIPTION
Related to #9 

This pull request includes a small but important fix to the `transaction.ts` file. The change ensures that `DEFAULT_ROW_INDEX` is explicitly checked to be of type `number`, improving type safety and preventing potential runtime issues.